### PR TITLE
render jsmind node in a synchronized mode

### DIFF
--- a/src/jsmind-test.jsx
+++ b/src/jsmind-test.jsx
@@ -18,7 +18,8 @@ const MindmapTest = () => {
     // import ReactDOM from "react-dom/client";
     // const root = ReactDOM.createRoot(element);
     // root.render(<span>{node.topic}</span>);
-    ReactDOM.render(<span>{node.topic}</span>, element)
+    // ReactDOM.render(<span>{node.topic}</span>, element)
+    element.innerHTML = `<span>${node.topic}</span>`
     return true
   }
 


### PR DESCRIPTION
`ReactDOM.render` 这个方法应该是异步执行的，我看它的方法签名里还有一个 callback 的参数。
你可以实验一下在 `render` 之后紧接着 `console.log(element.innerHTML)` 会发现里面是空的。

所以用 dom 的原生方法替换到 `ReactDOM.render`就可以了。

如果要 render 的内容比较复杂，想用 React 来构建的话，我觉得应该有某种方式能让 React 以同步的方式 render 这些 element.我搜索发现应该是可以做到的，但是我没弄出来。 😆 